### PR TITLE
Corrected JavaScript error in < IE8 with the need to quote "class".

### DIFF
--- a/jquery.tocible.js
+++ b/jquery.tocible.js
@@ -39,7 +39,7 @@
 			
 			if(opts.title){
 				var title = $(opts.title).length ? $(opts.title).text() : opts.title;
-				var head = $('<div/>', {class:'tocible_header', html:'<span/>'+title });
+				var head = $('<div/>', {'class':'tocible_header', html:'<span/>'+title });
 				
 				head.prependTo(nav).click(function() {
 					$(this).siblings('ul').slideToggle({
@@ -67,7 +67,7 @@
 				}
 				
 				anchor = $('<a/>', {text:title, href:href});				
-				list = $('<li/>', {class:'tocible_'+type});			
+				list = $('<li/>', {'class':'tocible_'+type});			
 				list.append(anchor).appendTo('.tocible > ul');
 							
 				anchor.click(function(e) {


### PR DESCRIPTION
Hey Mark, nice plugin. Thought I'd just add in a quick commit to fix an error I found in IE 8 and below. 

'class' is a reserved name. Minifying it autoquotes it, but I thought you'd like to get the correction in the raw js file too.
