### PR TITLE
Added a new option: offsetTopContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $('#container').tocible({
     title: '', //[selector or string], title of the menu
     hash: false, //[boolean], setting true will enable URL hashing on click
     offsetTop: 50, //[number], spacing/margin above the menu
+    offsetTopContent: 150, //[number], spacing/margin above the content
     speed: 800, //[number or string ('slow' & 'fast')], duration of the animation when jumping to the clicked content
     collapsible: true //[boolean], enabling true will auto collapse sub level heading not being scrolled into
     maxWidth: 150 //[number], set max-width of the navigation menu
@@ -50,7 +51,7 @@ $('#container').tocible({
 ````
 
 ## Compatibility
-Tested on modern browsers – Chrome, Firefox, Safari, also IE.
+Tested on modern browsers ï¿½ Chrome, Firefox, Safari, also IE.
 
 ## Changelog
 - 	v1.2.0 (24 Jun 2014)

--- a/jquery.tocible.js
+++ b/jquery.tocible.js
@@ -18,6 +18,7 @@
 		title:'',
 		hash:false,
 		offsetTop:50,
+		offsetTopContent:0,
 		speed:800,
 		collapsible:true,
 		maxWidth:150
@@ -89,7 +90,7 @@
 						$(window).scrollTop(winTop);
 					}
 					}		  
-					$('html, body').stop(true).animate({scrollTop:offset.top - 10}, opts.speed);
+					$('html, body').stop(true).animate({scrollTop:offset.top - 10 - opts.offsetTopContent}, opts.speed);
 				});
 				
 			});
@@ -131,7 +132,7 @@
 					target = $('.tocible li').eq(index),
 					winTop = $(window).scrollTop();
 			
-					if(winTop >= elTop - 20){
+					if(winTop >= elTop - 20 - opts.offsetTopContent){
 						target.addClass('toc_scrolled').siblings().removeClass('toc_scrolled');
 						if(opts.collapsible){
 							target.siblings().filter('.tocible_subheading').hide();


### PR DESCRIPTION
- added a new option, offsetTopContent, which can be used to offset the point at which the menu snaps to the next item (e.g. in case you have a top nav bar which lays sticks on top of the content area as you scroll down)

I found your plugin very useful in my project but it lacked a feature I needed. On my website, I have a top nav bar which stays at the top and overlays the content area as you scroll down. What this means is that as you navigate to an item in the menu, the content will snap to the very top of the page, making most of it invisible to the user. Adding the new property allows you to specify the height of the top nav bar by which the plugin will offset when snapping to the next item.
